### PR TITLE
Require tlc-transients at 1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require" : {
         "composer/installers" : "~1.0.0",
         "php" : ">=5.3.0",
-        "markjaquith/wp-tlc-transients" : "dev-master"
+        "markjaquith/wp-tlc-transients" : "^1.0"
     },
     "support": {
         "issues": "https://github.com/Shelob9/jp-rest-cache/issues",


### PR DESCRIPTION
This change means it's not necessary to downgrade one's composer project's `minimum-stability` to `dev` to satisfy the `wp-tlc-transients` dependency